### PR TITLE
fix: 토스트 처리 에러 해결

### DIFF
--- a/src/components/Toastify/index.ts
+++ b/src/components/Toastify/index.ts
@@ -1,11 +1,12 @@
 import { Slide, toast, ToastOptions, ToastPosition } from 'react-toastify';
 
 interface ToastProps {
-  type: 'success' | 'error' | 'loading' | 'update' | 'dismiss';
+  type: 'success' | 'error' | 'loading' | 'update' | 'dismiss' | 'render';
   iconType?: 'info' | 'success' | 'warning' | 'error' | 'default';
   message?: string;
   position?: ToastPosition;
   toastId?: string;
+  render?: 'success' | 'error'; 
 }
 
 const defaultToastOptions: ToastOptions = {
@@ -18,8 +19,8 @@ const defaultToastOptions: ToastOptions = {
   transition: Slide,
 };
 
-export const Toastify = ({ message, type, iconType, position, toastId }: ToastProps) => {
-  const toastConfig = {
+export const Toastify = ({ message, type, iconType, position, toastId, render }: ToastProps) => {
+  const toastConfig: ToastOptions = {
     ...defaultToastOptions,
     position: position || defaultToastOptions.position,
     toastId: toastId || undefined,
@@ -28,32 +29,33 @@ export const Toastify = ({ message, type, iconType, position, toastId }: ToastPr
 
   switch (type) {
     case 'success':
-      toast.success(message, {
-        ...toastConfig,
-
-      });
+      toast.success(message, toastConfig);
       return;
 
     case 'error':
-      toast.error(message, {
-        ...toastConfig,
-      });
+      toast.error(message, toastConfig);
       return;
 
     case 'loading':
-      toast.loading(message, {
-        ...toastConfig,
-      });
+      toast.loading(message, toastConfig);
       return;
+
     case 'update':
-      toast.update(toastId!, {
+      if (!toastId) return; // toastId 없으면 업데이트 불가
+      toast.update(toastId, {
         ...toastConfig,
+        render: message, 
+        type: render,
+        autoClose: defaultToastOptions.autoClose, 
+        isLoading: false,
       });
-      return
-    case 'dismiss':
-      toast.dismiss(toastId!);
       return;
+
+    case 'dismiss':
+      if (toastId) toast.dismiss(toastId);
+      return;
+
     default:
       toast(message, toastConfig);
   }
-}
+};

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -39,8 +39,9 @@ const Main = () => {
           Toastify({
             type: 'update',
             iconType: 'success',
-            message: '질문 생성 완료!',
+            message: '질문 생성이 완료되었습니다!',
             toastId: toastId,
+            render: 'success', 
           });
         },
         onError: (error) => {


### PR DESCRIPTION
## ⚙️ 작업 내용
토스트 처리 에러를 해결하였습니다.

## 🔎작업 상세 내용
- 로딩 토스트와 성공 토스트가 겹쳐 표시되어 부자연스러운 문제를 해결하기 위해, render 타입을 직접 지정할 수 있도록 수정했습니다.
```ts
toast.update(toastId, {
        ...toastConfig,
        render: message, 
        type: render,
        autoClose: defaultToastOptions.autoClose, 
        isLoading: false,
      });
      return;
```

## 📸 스크린샷

https://github.com/user-attachments/assets/e5853ccf-43eb-4ee3-97d3-a9f255267a2b

## ⚠️ 주의 사항 & 중점적으로 봐야 할 부분
- 없습니다.
